### PR TITLE
Only create new users do not update exsiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,10 +82,11 @@ async function capture(orders, storage) {
             financial_status: order.financial_status,
             created_at: order.created_at,
         }
-
-        if (customerEmail !== undefined) {
+        
+        //Only create new customers do not update them to avoid creating uncessessary events
+        if (customerEmail !== undefined && !customerRecordExists) {
             // to update a user, shouldn't we send properties in $set? 
-            posthog.capture(customerRecordExists ? 'Updated Shopify Customer' : 'Created Shopify Customer', {
+            posthog.capture('Created Shopify Customer', {
                 distinct_id: order.customer.email,
                 $set : {
                     ...order.customer


### PR DESCRIPTION
To prevent a loop that is causing a significant number of unneccessary events, do not update users only create new ones, we should not expect the customer data to change retroactively since orders are static in time.